### PR TITLE
spirv-headers 1.4.309.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,10 +15,9 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - {{ stdlib("c") }}
     - cmake
     - make    # [unix]
-    - ninja   # [win]
+    - ninja-base   # [win]
   host:
   run:
 
@@ -29,9 +28,13 @@ test:
 
 about:
   home: https://github.com/KhronosGroup/SPIRV-Headers
+  dev_url: https://github.com/KhronosGroup/SPIRV-Headers
+  doc_url: https://github.com/KhronosGroup/SPIRV-Headers
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
   summary: Machine-readable files for the SPIR-V Registry
+  description: Machine-readable files for the SPIR-V Registry
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-8139](https://anaconda.atlassian.net/browse/PKG-8139) 
- [Upstream repository](https://github.com/KhronosGroup/SPIRV-Headers/tree/vulkan-sdk-1.4.309.0)

### Explanation of changes:

- A new feedstock forked from conda-forge

### Notes:

-

[PKG-8139]: https://anaconda.atlassian.net/browse/PKG-8139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ