### PR TITLE
spirv-headers 1.4.341.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,25 +1,28 @@
-{% set name = "spirv-headers" %}
-{% set version = "1.4.309.0" %}
+{% set name = "SPIRV-Headers" %}
+# Keep this in synch with spirv-tools https://github.com/KhronosGroup/SPIRV-Tools/blob/v2026.1/DEPS#L17 ->
+# spirv_headers_revision': '04f10f650d514df88b76d25e83db360142c7b174 ->
+# https://github.com/KhronosGroup/SPIRV-Headers/commit/04f10f650d514df88b76d25e83db360142c7b174 ->
+# https://github.com/KhronosGroup/SPIRV-Headers/releases/tag/vulkan-sdk-1.4.341.0
+{% set version = "1.4.341.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  - url: https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-{{ version }}.tar.gz
-    sha256: a96f8b4f2dfb18f7432e5c523e220ab0075372a9509e0c25fbff21c76af0de7c
+  - url: https://github.com/KhronosGroup/{{ name }}/archive/refs/tags/vulkan-sdk-{{ version }}.tar.gz
+    sha256: cab0a654c4917e16367483296b44cdb1d614e3120c721beafcd37e3a8580486c
 
 build:
   number: 0
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
     - cmake
     - make    # [unix]
     - ninja-base   # [win]
-  host:
-  run:
 
 test:
   commands:


### PR DESCRIPTION
spirv-headers 1.4.341.0

**Destination channel:** defaults

### Links

- [PKG-13187](https://anaconda.atlassian.net/browse/PKG-13187) 
- [Upstream repository](https://github.com/KhronosGroup/SPIRV-Headers/tree/vulkan-sdk-1.4.341.0)

### Explanation of changes:

- version update


[PKG-13187]: https://anaconda.atlassian.net/browse/PKG-13187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ